### PR TITLE
Action display names

### DIFF
--- a/wlclient/src/PlayerAction.tsx
+++ b/wlclient/src/PlayerAction.tsx
@@ -3,6 +3,7 @@ import { PlayerState } from "wlcommon";
 export type StatePredicate = (playerState: PlayerState) => boolean;
 
 export class PlayerAction {
+    display: string;
     description: string;
     task: string;
     x: string;
@@ -11,7 +12,8 @@ export class PlayerAction {
     getEnabled?: StatePredicate;
     isVisible: boolean;
     isEnabled: boolean;
-    constructor(description: string, task: string, x: string, y: string, visibility?: StatePredicate, enabled?: StatePredicate) {
+    constructor(display: string, description: string, task: string, x: string, y: string, visibility?: StatePredicate, enabled?: StatePredicate) {
+        this.display = display;
         this.description = description;
         this.task = task;
         this.x = x;
@@ -30,6 +32,7 @@ export class DynamicPlayerAction extends PlayerAction {
     triggerEffectsIfNotRecent: (v: ((b: boolean) => void), e: ((b: boolean) => void)) => void;
     
     constructor(
+            display: string,
             description: string,
             task: string,
             x: string,
@@ -41,7 +44,7 @@ export class DynamicPlayerAction extends PlayerAction {
             visibility?: StatePredicate,
             enabled?: StatePredicate
     ) {
-        super(description, task, x, y, visibility, enabled);
+        super(display, description, task, x, y, visibility, enabled);
         this.timeToCompare = timeToCompare;
         this.howRecentToTrigger = howRecentToTrigger;
         this.triggerEffectsIfRecent = triggerEffectsIfRecent;

--- a/wlclient/src/components/BottomBar/QuestInfo.tsx
+++ b/wlclient/src/components/BottomBar/QuestInfo.tsx
@@ -27,7 +27,7 @@ const QuestInfo = (props: QuestInfoProps): React.ReactElement => {
     return (
         <div className="questInfo">
             <h4 className="questName">{questName}</h4>
-            { questSteps.map((info) => <p key="" className="questStep">{info}</p>) }
+            { questSteps.map((info, index) => <p key={index} className="questStep">{info}</p>) }
         </div>
     );
 };

--- a/wlclient/src/components/BottomBar/QuestLog.tsx
+++ b/wlclient/src/components/BottomBar/QuestLog.tsx
@@ -18,8 +18,8 @@ const QuestLog = (props: QuestLogProps): React.ReactElement => {
         <div className="questLog">
             <h2 className="questTitle">QUESTS</h2>
             <div className="innerQuestBox">
-                {questStates.map((item: QuestState) => (
-                    <QuestInfo key="" questState={item} />
+                {questStates.map((item: QuestState, index) => (
+                    <QuestInfo key={index} questState={item} />
                 ))}
             </div>
         </div>

--- a/wlclient/src/components/Game.tsx
+++ b/wlclient/src/components/Game.tsx
@@ -98,6 +98,7 @@ const Game = (props: GameProps): React.ReactElement => {
                 triggerTooltip={triggerTooltip}
             />
             <LocationComponent 
+                globalState={globalState}
                 playerState={playerState} 
                 handleAction={handleSpecificAction} 
                 handleTravel={handleTravel}

--- a/wlclient/src/components/Location/Action.css
+++ b/wlclient/src/components/Location/Action.css
@@ -1,6 +1,6 @@
 .action {
     position: absolute;
-    width: 133px;
+    width: 140px;
     height: 39px;
     color: #4AE0A0;
     font-size: 16px;

--- a/wlclient/src/components/Location/Action.tsx
+++ b/wlclient/src/components/Location/Action.tsx
@@ -15,7 +15,7 @@ export interface ActionProps {
 }
 
 export const Action = (props: ActionProps): React.ReactElement => {
-    const { display, action, x, y, isVisible, isEnabled, handleAction, triggerTooltip, tooltipInfo } = props;
+    const { display, x, y, isVisible, isEnabled, handleAction, triggerTooltip, tooltipInfo } = props;
     
     const position = {
         top: y,

--- a/wlclient/src/components/Location/Action.tsx
+++ b/wlclient/src/components/Location/Action.tsx
@@ -3,6 +3,7 @@ import { tooltipTypes, TooltipType } from '../Popups/Tooltip';
 import './Action.css';
 
 export interface ActionProps {
+    display: string;
     action: string;
     x: string;
     y: string;
@@ -14,7 +15,7 @@ export interface ActionProps {
 }
 
 export const Action = (props: ActionProps): React.ReactElement => {
-    const { action, x, y, isVisible, isEnabled, handleAction, triggerTooltip, tooltipInfo } = props;
+    const { display, action, x, y, isVisible, isEnabled, handleAction, triggerTooltip, tooltipInfo } = props;
     
     const position = {
         top: y,
@@ -32,7 +33,7 @@ export const Action = (props: ActionProps): React.ReactElement => {
             onMouseEnter={triggerTooltip(tooltipTypes.ACTION, tooltipInfo ? tooltipInfo : ["derp", "", ""], isTooltipRightSide)}
             onMouseLeave={triggerTooltip()}
         >
-            <p>{action}</p>
+            <p>{display}</p>
         </div>
     );
 };

--- a/wlclient/src/components/Location/Alcove.tsx
+++ b/wlclient/src/components/Location/Alcove.tsx
@@ -36,7 +36,7 @@ const Alcove = (props: SpecificLocationProps): React.ReactElement => {
             playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
         handleAction: handleAction(actionId),
         triggerTooltip: triggerTooltip,
-        tooltipInfo: [actionId, playerAction.description, playerAction.task]
+        tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
 
     return (

--- a/wlclient/src/components/Location/Alcove.tsx
+++ b/wlclient/src/components/Location/Alcove.tsx
@@ -5,16 +5,16 @@ import { Actions, itemDetails } from 'wlcommon';
 import { PlayerAction } from '../../PlayerAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.ALCOVE.RETRIEVE_PEARL]: new PlayerAction("You know what you're here for.", 
+    [Actions.specificActions.ALCOVE.RETRIEVE_PEARL]: new PlayerAction("Retrieve Pearl", "You know what you're here for.", 
         "Receive 1 x Pearl of Asclepius.", "409px", "399px",
         (playerState) => playerState.inventory[itemDetails.UNICORN_TEAR.id] == null),
-    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
         "No task required.", "870px", "488px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
         "No task required.", "870px", "543px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
         "No task required.", "729px", "101px")
 }
 
@@ -22,6 +22,7 @@ const Alcove = (props: SpecificLocationProps): React.ReactElement => {
     const { playerState, handleAction, triggerTooltip, isMentor } = props;
 
     const actionProps = Object.entries(actions).map(([actionId, playerAction]) => ({
+        display: playerAction.display,
         action: actionId,
         x: playerAction.x,
         y: playerAction.y,

--- a/wlclient/src/components/Location/Anchovy.tsx
+++ b/wlclient/src/components/Location/Anchovy.tsx
@@ -6,22 +6,22 @@ import { DynamicPlayerAction, PlayerAction } from '../../PlayerAction';
 import DynamicAction, { DynamicActionProps } from './DynamicAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.ANCHOVY.EXPLORE]: new DynamicPlayerAction("Anchovy Avenue is a residential district. The Chief Librarian of the Marine Library is said to live here.", 
+    [Actions.specificActions.ANCHOVY.EXPLORE]: new DynamicPlayerAction("Explore", "Anchovy Avenue is a residential district. The Chief Librarian of the Marine Library is said to live here.", 
         "Use 5 minutes of Oxygen.", "466px", "354px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         300000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },),
-    [Actions.specificActions.ANCHOVY.INSPIRE]: new PlayerAction("Inspire the Chief Librarian with your leadership!", 
+    [Actions.specificActions.ANCHOVY.INSPIRE]: new PlayerAction("Inspire", "Inspire the Chief Librarian with your leadership!", 
         "Have any member of your team perform Project Inspire.", "294px", "533px",
         (playerState) => playerState.quests[questIds.LIBRARIAN_PASS]?.status === 'incomplete'),
-    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
         "No task required.", "870px", "488px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
         "No task required.", "870px", "543px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
         "No task required.", "209px", "120px")
 }
 
@@ -31,6 +31,7 @@ const Anchovy = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -53,6 +54,7 @@ const Anchovy = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -77,7 +79,7 @@ const Anchovy = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('anchovy.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Anchovy.tsx
+++ b/wlclient/src/components/Location/Anchovy.tsx
@@ -45,7 +45,7 @@ const Anchovy = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -68,7 +68,7 @@ const Anchovy = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Barnacle.tsx
+++ b/wlclient/src/components/Location/Barnacle.tsx
@@ -45,7 +45,7 @@ const Barnacle = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -68,7 +68,7 @@ const Barnacle = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Barnacle.tsx
+++ b/wlclient/src/components/Location/Barnacle.tsx
@@ -6,22 +6,22 @@ import { DynamicPlayerAction, PlayerAction } from '../../PlayerAction';
 import DynamicAction, { DynamicActionProps } from './DynamicAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.BARNACLE.EXPLORE]: new DynamicPlayerAction("Barnacle Residences is a residential district. The Pyrite Lady is said to live here.", 
+    [Actions.specificActions.BARNACLE.EXPLORE]: new DynamicPlayerAction("Explore", "Barnacle Residences is a residential district. The Pyrite Lady is said to live here.", 
         "Use 5 minutes of Oxygen.", "445px", "211px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         300000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },),
-    [Actions.specificActions.BARNACLE.HELP]: new PlayerAction("The Pyrite Lady has mixed up some of her potion ingredients. Help her!", 
+    [Actions.specificActions.BARNACLE.HELP]: new PlayerAction("Help", "The Pyrite Lady has mixed up some of her potion ingredients. Help her!", 
         "Create a list of youngest to oldest of your whole group.", "437px", "471px",
         (playerState) => playerState.quests[questIds.PYRITE]?.status === 'incomplete'),
-    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
         "No task required.", "870px", "488px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
         "No task required.", "870px", "543px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
         "No task required.", "729px", "113px")
 }
 
@@ -31,6 +31,7 @@ const Barnacle = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -53,6 +54,7 @@ const Barnacle = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -77,7 +79,7 @@ const Barnacle = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('barnacle.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Bubble.tsx
+++ b/wlclient/src/components/Location/Bubble.tsx
@@ -47,7 +47,7 @@ const Bubble = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -70,7 +70,7 @@ const Bubble = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Bubble.tsx
+++ b/wlclient/src/components/Location/Bubble.tsx
@@ -13,15 +13,15 @@ const Bubble = (props: SpecificLocationProps): React.ReactElement => {
         : "";
 
     const actions: Record<string, PlayerAction> = {
-        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
             "No task required.", "870px", "488px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
             "No task required.", "870px", "543px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
             "No task required.", "434px", "524px"),
-        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("Each of you has to show a different item from the following: Pencil case, phone application and items you bring on a holiday." + coolDownMessage, 
+        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("Get Oxygen", "Each of you has to show a different item from the following: Pencil case, phone application and items you bring on a holiday." + coolDownMessage, 
             "Recite Red Cross Promise.", "55px", "239px",
             (playerState) => playerState.streamCooldownExpiry[playerState.locationId] ? new Date(playerState.streamCooldownExpiry[playerState.locationId]) : new Date(0),
             0,
@@ -33,6 +33,7 @@ const Bubble = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -55,6 +56,7 @@ const Bubble = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -79,7 +81,7 @@ const Bubble = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('bubble.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Catfish.tsx
+++ b/wlclient/src/components/Location/Catfish.tsx
@@ -13,15 +13,15 @@ const Catfish = (props: SpecificLocationProps): React.ReactElement => {
         : "";
 
     const actions: Record<string, PlayerAction> = {
-        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
             "No task required.", "870px", "488px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
             "No task required.", "870px", "543px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
             "No task required.", "169px", "348px"),
-        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("The Oxygen Stream at Catfish Crescent is curiously linked with the one located at Salmon Street. Both need to be activated at roughly the same time, before you can receive 40 minutes of Oxygen." + coolDownMessage, 
+        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("Get Oxygen", "The Oxygen Stream at Catfish Crescent is curiously linked with the one located at Salmon Street. Both need to be activated at roughly the same time, before you can receive 40 minutes of Oxygen." + coolDownMessage, 
             "Recite Red Cross Promise.", "558px", "152px",
             (playerState) => playerState.streamCooldownExpiry[playerState.locationId] ? new Date(playerState.streamCooldownExpiry[playerState.locationId]) : new Date(0),
             0,
@@ -32,6 +32,7 @@ const Catfish = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -54,6 +55,7 @@ const Catfish = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -78,7 +80,7 @@ const Catfish = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('catfish.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Catfish.tsx
+++ b/wlclient/src/components/Location/Catfish.tsx
@@ -46,7 +46,7 @@ const Catfish = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -69,7 +69,7 @@ const Catfish = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Corals.tsx
+++ b/wlclient/src/components/Location/Corals.tsx
@@ -57,7 +57,7 @@ const Corals = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -80,7 +80,7 @@ const Corals = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Corals.tsx
+++ b/wlclient/src/components/Location/Corals.tsx
@@ -12,26 +12,26 @@ const Corals = (props: SpecificLocationProps): React.ReactElement => {
         ? " You may reuse this service again at " + new Date(playerState.streamCooldownExpiry[playerState.locationId]).toLocaleTimeString()
         : "";
     const actions: Record<string, PlayerAction> = {
-        [Actions.specificActions.CORALS.EXPLORE]: new DynamicPlayerAction("The Memorial Corals is a location of historical importance. There are various exhibits in the park. You can spend some time to look around the exhibits.", 
+        [Actions.specificActions.CORALS.EXPLORE]: new DynamicPlayerAction("Explore", "The Memorial Corals is a location of historical importance. There are various exhibits in the park. You can spend some time to look around the exhibits.", 
             "Use 5 minutes of Oxygen.", "743px", "265px",
             (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
             300000,
             (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
             (): void => { return; },),
-        [Actions.specificActions.CORALS.LEARN_LANG]: new PlayerAction(
+        [Actions.specificActions.CORALS.LEARN_LANG]: new PlayerAction("Learn Language", 
             "The ancient language of the Undersea is interesting. Devote some time to learning it.", 
             "Gather items: 2 brushes, 2 pieces of paper, 2 storybooks; Each person then has to say 'hi' in a different language and say what language it is.",
             "427px", "419px",
             (playerState) => playerState.quests[questIds.FINCHES]?.status === 'incomplete'),
-        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
             "No task required.", "870px", "488px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
             "No task required.", "870px", "543px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
             "No task required.", "26px", "106px"),
-        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("There is a small oxygen stream at the Memorial Corals. By Undersea law, after topping up Oxygen, you must wait 5 minutes before you can top up Oxygen at the same Oxygen Stream." + coolDownMessage, 
+        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("Get Oxygen", "There is a small oxygen stream at the Memorial Corals. By Undersea law, after topping up Oxygen, you must wait 5 minutes before you can top up Oxygen at the same Oxygen Stream." + coolDownMessage, 
             "Each person has to present a fully filled water bottle to the mentors to receive 20 minutes of Oxygen.",
             "108px", "438px",
             (playerState) => playerState.streamCooldownExpiry[playerState.locationId] ? new Date(playerState.streamCooldownExpiry[playerState.locationId]) : new Date(0),
@@ -43,6 +43,7 @@ const Corals = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -65,6 +66,7 @@ const Corals = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,

--- a/wlclient/src/components/Location/DynamicAction.tsx
+++ b/wlclient/src/components/Location/DynamicAction.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Action from './Action';
 import { ActionProps } from './Action';
-import { PlayerState } from 'wlcommon';
 
 export interface DynamicActionProps {
     actionProps: ActionProps;

--- a/wlclient/src/components/Location/Kelp.tsx
+++ b/wlclient/src/components/Location/Kelp.tsx
@@ -47,7 +47,7 @@ const Kelp = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -70,7 +70,7 @@ const Kelp = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Kelp.tsx
+++ b/wlclient/src/components/Location/Kelp.tsx
@@ -6,24 +6,24 @@ import { DynamicPlayerAction, PlayerAction } from '../../PlayerAction';
 import DynamicAction, { DynamicActionProps } from './DynamicAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.KELP.EXPLORE]: new DynamicPlayerAction("The Kelp Plains is full of seaweed, and stretches for miles and miles, and is full of seaweed. Perhaps you can find what you're looking for here.", 
+    [Actions.specificActions.KELP.EXPLORE]: new DynamicPlayerAction("Explore", "The Kelp Plains is full of seaweed, and stretches for miles and miles, and is full of seaweed. Perhaps you can find what you're looking for here.", 
         "Use 5 minutes of Oxygen.", "73px", "347px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         300000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },),
-    [Actions.specificActions.KELP.CLIMB_DOWN]: new PlayerAction("You have found a small shrine tucked away in a valley. However, the journey there looks difficult.", 
+    [Actions.specificActions.KELP.CLIMB_DOWN]: new PlayerAction("Climb Down", "You have found a small shrine tucked away in a valley. However, the journey there looks difficult.", 
         "Online Maze: https://www.mathsisfun.com/games/mazes.html. Complete one Hard maze.", "360px", "487px",
         (playerState) => playerState.quests[questIds.SHRINE_1]?.status === 'incomplete'),
-    [Actions.specificActions.KELP.HARVEST]: new PlayerAction("Harvest some blinkseed here.", 
+    [Actions.specificActions.KELP.HARVEST]: new PlayerAction("Harvest", "Harvest some blinkseed here.", 
         "Have a member receive a message from the mentors. The rest of you have to lipread what he/she is saying.", "510px", "284px"),
-    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
         "No task required.", "870px", "488px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
         "No task required.", "870px", "543px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
         "No task required.", "122px", "117px")
 }
 
@@ -33,6 +33,7 @@ const Kelp = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -55,6 +56,7 @@ const Kelp = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -79,7 +81,7 @@ const Kelp = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('kelp.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Library.tsx
+++ b/wlclient/src/components/Location/Library.tsx
@@ -6,31 +6,31 @@ import { DynamicPlayerAction, PlayerAction } from '../../PlayerAction';
 import DynamicAction, { DynamicActionProps } from './DynamicAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.LIBRARY.EXPLORE]: new DynamicPlayerAction("Talk to the librarians about the Marine Library.", 
+    [Actions.specificActions.LIBRARY.EXPLORE]: new DynamicPlayerAction("Explore", "Talk to the librarians about the Marine Library.", 
         "Use 5 minutes of Oxygen.", "432px", "385px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         300000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },),
-    [Actions.specificActions.LIBRARY.STUDY_CRIMSON]: new PlayerAction("Learn more about the Crimson, a crisis that took place 10,000 years ago.", 
+    [Actions.specificActions.LIBRARY.STUDY_CRIMSON]: new PlayerAction("Study Crimson", "Learn more about the Crimson, a crisis that took place 10,000 years ago.", 
         "Have any member share an incident when things did not go as planned for a training/ project and how did the plan get adapted.", "99px", "503px",
         (playerState) => playerState.quests[questIds.FINCHES_2]?.status === 'incomplete',
         (playerState) => playerState.inventory[itemDetails.LIBRARY_PASS.id] !== undefined),
-    [Actions.specificActions.LIBRARY.STUDY_ARTEFACT]: new PlayerAction("Learn more about the artefacts.", 
+    [Actions.specificActions.LIBRARY.STUDY_ARTEFACT]: new PlayerAction("Study Artefact", "Learn more about the artefacts.", 
         "Create a new group cheer and do it to energise yourselves.", "630px", "202px",
         (playerState) => playerState.quests[questIds.ARTEFACTS_1]?.status === 'incomplete',
         (playerState) => playerState.inventory[itemDetails.LIBRARY_PASS.id] !== undefined),
-    [Actions.specificActions.LIBRARY.DECODE_ARTEFACT]: new PlayerAction("The artefact legend is written in an ancient language. You will need to decode it before you can understand it.", 
+    [Actions.specificActions.LIBRARY.DECODE_ARTEFACT]: new PlayerAction("Decode Artefact", "The artefact legend is written in an ancient language. You will need to decode it before you can understand it.", 
         "Decode 'Hwljaxawv Ljalgf'.", "703px", "265px",
         (playerState) => playerState.quests[questIds.ARTEFACTS_2]?.status === 'incomplete',
         (playerState) => playerState.knowsLanguage),
-    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
         "No task required.", "870px", "488px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
         "No task required.", "870px", "543px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
         "No task required.", "33px", "171px")
 }
 
@@ -40,6 +40,7 @@ const Library = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -62,6 +63,7 @@ const Library = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -86,7 +88,7 @@ const Library = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('Library.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Library.tsx
+++ b/wlclient/src/components/Location/Library.tsx
@@ -54,7 +54,7 @@ const Library = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -77,7 +77,7 @@ const Library = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/LocationComponent.css
+++ b/wlclient/src/components/Location/LocationComponent.css
@@ -16,5 +16,7 @@
     border: 1px solid black;
     color: antiquewhite;
     font-weight: bold;
-    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }

--- a/wlclient/src/components/Location/LocationComponent.tsx
+++ b/wlclient/src/components/Location/LocationComponent.tsx
@@ -162,13 +162,12 @@ const LocationComponent = (props: LocationProps): React.ReactElement => {
     
     return (
         <div className="location">
-            <p 
+            <div
                 className="currLocationTitle"
                 onMouseEnter={triggerTooltip(tooltipTypes.LOCATION, [playerState.locationId])}
                 onMouseLeave={triggerTooltip()}
-            >
-                {location.name}
-            </p>
+            ><span> {location.name} </span>
+            </div>
             { getSpecificLocationComponent(globalState,
                 playerState, handleAction, triggerTooltip, isMentor) }
             <Action {...travelActionProps} />

--- a/wlclient/src/components/Location/LocationComponent.tsx
+++ b/wlclient/src/components/Location/LocationComponent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Action, ActionProps } from './Action';
 import TravelPopup from './TravelPopup';
 import { TooltipType, tooltipTypes } from '../Popups/Tooltip';
-import { Locations, PlayerState } from 'wlcommon';
+import { GlobalState, Locations, PlayerState } from 'wlcommon';
 import './LocationComponent.css';
 
 import Shallows from './Shallows';
@@ -24,6 +24,7 @@ import Shrine from './Shrine';
 import Alcove from './Alcove';
 
 export interface LocationProps {
+    globalState: GlobalState;
     playerState: PlayerState;
     handleAction: (a: string) => () => void;
     handleTravel: (a: Locations.LocationId) => () => void;
@@ -32,18 +33,22 @@ export interface LocationProps {
 }
 
 export interface SpecificLocationProps {
+    globalState?: GlobalState;
     playerState: PlayerState;
     handleAction: (a: string) => () => void;
     triggerTooltip: (t?: TooltipType, d?: string[], b?: boolean) => () => void;
     isMentor?: boolean;
 }
 
-export function getSpecificLocationComponent(playerState: PlayerState,
+export function getSpecificLocationComponent(
+    globalState: GlobalState,
+    playerState: PlayerState,
     handleAction: (a: string) => () => void, 
     triggerTooltip: (t?: TooltipType, d?: string[], b?: boolean) => () => void,
     isMentor?: boolean): React.ReactElement {
         
     const specificLocationComponentProps = {
+        globalState: globalState,
         playerState: playerState,
         handleAction: handleAction,
         triggerTooltip: triggerTooltip,
@@ -53,71 +58,71 @@ export function getSpecificLocationComponent(playerState: PlayerState,
     const SPECIFIC_LOCATION_COMPONENT_MAP: Map<Locations.LocationId, React.ReactElement> = new Map([
         [
             Locations.locationIds.SHALLOWS, 
-            <Shallows key="" {...specificLocationComponentProps} />
+            <Shallows key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.SHORES, 
-            <Shores key="" {...specificLocationComponentProps} />
+            <Shores key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.CORALS, 
-            <Corals key="" {...specificLocationComponentProps} />
+            <Corals key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.STORE, 
-            <Store key="" {...specificLocationComponentProps} />
+            <Store key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.WOODS, 
-            <Woods key="" {...specificLocationComponentProps} />
+            <Woods key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.STATUE, 
-            <Statue key="" {...specificLocationComponentProps} />
+            <Statue key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.LIBRARY, 
-            <Library key="" {...specificLocationComponentProps} />
+            <Library key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.ANCHOVY, 
-            <Anchovy key="" {...specificLocationComponentProps} />
+            <Anchovy key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.BARNACLE, 
-            <Barnacle key="" {...specificLocationComponentProps} />
+            <Barnacle key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.SALMON, 
-            <Salmon key="" {...specificLocationComponentProps} />
+            <Salmon key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.KELP, 
-            <Kelp key="" {...specificLocationComponentProps} />
+            <Kelp key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.UMBRAL, 
-            <Umbral key="" {...specificLocationComponentProps} />
+            <Umbral key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.TUNA, 
-            <Tuna key="" {...specificLocationComponentProps} />
+            <Tuna key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.CATFISH, 
-            <Catfish key="" {...specificLocationComponentProps} />
+            <Catfish key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.BUBBLE, 
-            <Bubble key="" {...specificLocationComponentProps} />
+            <Bubble key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.SHRINE, 
-            <Shrine key="" {...specificLocationComponentProps} />
+            <Shrine key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
         [
             Locations.locationIds.ALCOVE, 
-            <Alcove key="" {...specificLocationComponentProps} />
+            <Alcove key={Math.random.toString()} {...specificLocationComponentProps} />
         ],
     ]);
     
@@ -133,13 +138,14 @@ export function imgDirectoryGenerator(imgFileName: string): string {
 }
 
 const LocationComponent = (props: LocationProps): React.ReactElement => {
-    const { playerState, handleAction, handleTravel, triggerTooltip, isMentor } = props;
+    const { globalState, playerState, handleAction, handleTravel, triggerTooltip, isMentor } = props;
     
     const location: Locations.Location = Locations.locationsMapping[playerState.locationId];
     
     const isTravelVisible = playerState.locationId != Locations.locationIds.SHORES || playerState.unlockedWoods == true;
     const [isTravelPopupVisible, setIsTravelPopupVisible] = React.useState(false);  
     const travelActionProps: ActionProps = {
+        display: "Travel",
         action: "Travel",
         x: "870px",
         y: "433px",
@@ -163,8 +169,8 @@ const LocationComponent = (props: LocationProps): React.ReactElement => {
             >
                 {location.name}
             </p>
-            { getSpecificLocationComponent(playerState, 
-                handleAction, triggerTooltip, isMentor) }
+            { getSpecificLocationComponent(globalState,
+                playerState, handleAction, triggerTooltip, isMentor) }
             <Action {...travelActionProps} />
             <TravelPopup
                 playerState={playerState}

--- a/wlclient/src/components/Location/Salmon.tsx
+++ b/wlclient/src/components/Location/Salmon.tsx
@@ -55,7 +55,7 @@ const Salmon = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -78,7 +78,7 @@ const Salmon = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Salmon.tsx
+++ b/wlclient/src/components/Location/Salmon.tsx
@@ -13,24 +13,24 @@ const Salmon = (props: SpecificLocationProps): React.ReactElement => {
         : "";
 
     const actions: Record<string, PlayerAction> = {
-        [Actions.specificActions.SALMON.EXPLORE]: new DynamicPlayerAction("Salmon Street is a residential district. It was built around an Oxygen Stream located here.", 
+        [Actions.specificActions.SALMON.EXPLORE]: new DynamicPlayerAction("Explore", "Salmon Street is a residential district. It was built around an Oxygen Stream located here.", 
             "Use 5 minutes of Oxygen.", "578px", "362px",
             (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
             300000,
             (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
             (): void => { return; },),
-        [Actions.specificActions.SALMON.CONFRONT]: new PlayerAction("The children are chasing each other with the long and pointy stick. Tell them what is right.", 
+        [Actions.specificActions.SALMON.CONFRONT]: new PlayerAction("Confront", "The children are chasing each other with the long and pointy stick. Tell them what is right.", 
             "Have any member of your team perform Project MTW.", "142px", "542px",
             (playerState) => playerState.quests[questIds.ARGUMENT]?.status === 'incomplete'),
-        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
             "No task required.", "870px", "488px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
             "No task required.", "870px", "543px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
             "No task required.", "18px", "96px"),
-        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("The Oxygen Stream at Salmon Street is curiously linked with the one located at Catfish Crescent. Both need to be activated at roughly the same time, before you can receive 40 minutes of Oxygen." + coolDownMessage, 
+        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("Get Oxygen", "The Oxygen Stream at Salmon Street is curiously linked with the one located at Catfish Crescent. Both need to be activated at roughly the same time, before you can receive 40 minutes of Oxygen." + coolDownMessage, 
             "Recite Red Cross Promise.", "827px", "127px",
             (playerState) => playerState.streamCooldownExpiry[playerState.locationId] ? new Date(playerState.streamCooldownExpiry[playerState.locationId]) : new Date(0),
             0,
@@ -41,6 +41,7 @@ const Salmon = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -63,6 +64,7 @@ const Salmon = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -87,7 +89,7 @@ const Salmon = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('salmon.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Shallows.tsx
+++ b/wlclient/src/components/Location/Shallows.tsx
@@ -5,13 +5,13 @@ import { Actions } from 'wlcommon';
 import { PlayerAction } from '../../PlayerAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
         "No task required.", "870px", "488px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
         "No task required.", "870px", "543px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
         "No task required.", "45px", "120px")
 }
 
@@ -19,6 +19,7 @@ const Shallows = (props: SpecificLocationProps): React.ReactElement => {
     const { playerState, handleAction, triggerTooltip, isMentor } = props;
 
     const actionProps = Object.entries(actions).map(([actionId, playerAction]) => ({
+        display: playerAction.display,
         action: actionId,
         x: playerAction.x,
         y: playerAction.y,

--- a/wlclient/src/components/Location/Shallows.tsx
+++ b/wlclient/src/components/Location/Shallows.tsx
@@ -33,7 +33,7 @@ const Shallows = (props: SpecificLocationProps): React.ReactElement => {
             playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
         handleAction: handleAction(actionId),
         triggerTooltip: triggerTooltip,
-        tooltipInfo: [actionId, playerAction.description, playerAction.task]
+        tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
 
     return (

--- a/wlclient/src/components/Location/Shores.tsx
+++ b/wlclient/src/components/Location/Shores.tsx
@@ -5,7 +5,7 @@ import { Actions } from 'wlcommon';
 import { PlayerAction } from '../../PlayerAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.SHORES.DIVE]: new PlayerAction("Dive into the deep, blue sea. After diving, you will enter the Shallows location inside the Undersea. You will start your dive with 20 minutes of Oxygen.", 
+    [Actions.specificActions.SHORES.DIVE]: new PlayerAction("Dive", "Dive into the deep, blue sea. After diving, you will enter the Shallows location inside the Undersea. You will start your dive with 20 minutes of Oxygen.", 
         "Create a shape resembling a diving board with all of your arms.", "445px", "309px")
 }
 
@@ -13,6 +13,7 @@ const Shores = (props: SpecificLocationProps): React.ReactElement => {
     const { playerState, handleAction, triggerTooltip, isMentor } = props;
     
     const actionProps = Object.entries(actions).map(([actionId, playerAction]) => ({
+        display: playerAction.display,
         action: actionId,
         x: playerAction.x,
         y: playerAction.y,

--- a/wlclient/src/components/Location/Shores.tsx
+++ b/wlclient/src/components/Location/Shores.tsx
@@ -27,7 +27,7 @@ const Shores = (props: SpecificLocationProps): React.ReactElement => {
             playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
         handleAction: handleAction(actionId),
         triggerTooltip: triggerTooltip,
-        tooltipInfo: [actionId, playerAction.description, playerAction.task]
+        tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
 
     return (

--- a/wlclient/src/components/Location/Shrine.tsx
+++ b/wlclient/src/components/Location/Shrine.tsx
@@ -5,20 +5,20 @@ import { Actions, itemDetails, questIds } from 'wlcommon';
 import { PlayerAction } from '../../PlayerAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.SHRINE.GIVE_HAIR]: new PlayerAction("The shrinekeeper says he can transform a Unicorn's Hair into a Unicorn's Tear.", 
+    [Actions.specificActions.SHRINE.GIVE_HAIR]: new PlayerAction("Give Hair", "The shrinekeeper says he can transform a Unicorn's Hair into a Unicorn's Tear.", 
         "Give 1 x Unicorn's Hair.", "434px", "449px", undefined,
         (playerState) => playerState.inventory[itemDetails.UNICORN_HAIR.id] !== undefined),
-    [Actions.specificActions.SHRINE.COLLECT_HAIR]: new PlayerAction("Collect the Unicorn Tear from the Shrine.", 
+    [Actions.specificActions.SHRINE.COLLECT_HAIR]: new PlayerAction("Collect Tear", "Collect the Unicorn Tear from the Shrine.", 
         "Receive 1 x Unicorn Tear.", "434px", "495px",
         (playerState) => playerState.quests[questIds.SHRINE_2]?.stages[4],
         (playerState) => playerState.inventory[itemDetails.UNICORN_TEAR.id] == undefined),
-    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
         "No task required.", "870px", "488px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
         "No task required.", "870px", "543px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
         "No task required.", "52px", "123px")
 }
 
@@ -26,6 +26,7 @@ const Shrine = (props: SpecificLocationProps): React.ReactElement => {
     const { playerState, handleAction, triggerTooltip, isMentor } = props;
 
     const actionProps = Object.entries(actions).map(([actionId, playerAction]) => ({
+        display: playerAction.display,
         action: actionId,
         x: playerAction.x,
         y: playerAction.y,

--- a/wlclient/src/components/Location/Shrine.tsx
+++ b/wlclient/src/components/Location/Shrine.tsx
@@ -40,7 +40,7 @@ const Shrine = (props: SpecificLocationProps): React.ReactElement => {
             playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
         handleAction: handleAction(actionId),
         triggerTooltip: triggerTooltip,
-        tooltipInfo: [actionId, playerAction.description, playerAction.task]
+        tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
 
     return (

--- a/wlclient/src/components/Location/Statue.tsx
+++ b/wlclient/src/components/Location/Statue.tsx
@@ -6,44 +6,47 @@ import { DynamicPlayerAction, PlayerAction } from '../../PlayerAction';
 import DynamicAction, { DynamicActionProps } from './DynamicAction';
 
 const Statue = (props: SpecificLocationProps): React.ReactElement => {
-    const { playerState, handleAction, triggerTooltip, isMentor } = props;
+    const { globalState, playerState, handleAction, triggerTooltip, isMentor } = props;
 
     const coolDownMessage = playerState.streamCooldownExpiry[playerState.locationId]
         ? " You may reuse this service again at " + new Date(playerState.streamCooldownExpiry[playerState.locationId]).toLocaleTimeString()
         : "";
 
+    const lastUsedMessage = globalState // && globalState?.tritonOxygen.lastExtract
+        ? " This Oxygen stream was last used on " + new Date(globalState?.tritonOxygen.lastExtract).toLocaleTimeString()
+        : " No group has used this Oxygen stream yet! Be the first!";
     const actions: Record<string, PlayerAction> = {
-        [Actions.specificActions.STATUE.EXPLORE]: new DynamicPlayerAction("The Statue of Triton is a monument to Triton, famed hero of the Undersea. Walk around the statue to learn more about Triton.", 
+        [Actions.specificActions.STATUE.EXPLORE]: new DynamicPlayerAction("Explore", "The Statue of Triton is a monument to Triton, famed hero of the Undersea. Walk around the statue to learn more about Triton.", 
             "Use 5 minutes of Oxygen.", "256px", "441px",
             (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
             300000,
             (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
             (): void => { return; },),
-        [Actions.specificActions.STATUE.DECODE_ENGRAVING]: new PlayerAction("You have found an engraving written in the ancient language. Decode it to learn what it says.", 
+        [Actions.specificActions.STATUE.DECODE_ENGRAVING]: new PlayerAction("Decode Engraving", "You have found an engraving written in the ancient language. Decode it to learn what it says.", 
             "Decode 'Vwwh Ujaekgf'", "250px", "553px",
             (playerState) => playerState.knowsLanguage),
-        [Actions.specificActions.STATUE.CAST_COOLING_AURA]: new PlayerAction("The Crimson's body temperature is kept low as part of its slumber. Prevent it from getting too high!",
+        [Actions.specificActions.STATUE.CAST_COOLING_AURA]: new PlayerAction("Cast Aura", "The Crimson's body temperature is kept low as part of its slumber. Prevent it from getting too high!",
             "Water Parade.", "414px", "324px",
             (playerState) => playerState.knowsCrimson),
-        [Actions.specificActions.STATUE.STRENGTHEN_BEFUDDLEMENT]: new PlayerAction("A Befuddlement Spell keeps the Crimson from waking up. However, it may weaken over time, and you will have to strengthen it.",
+        [Actions.specificActions.STATUE.STRENGTHEN_BEFUDDLEMENT]: new PlayerAction("Befuddle Harder", "A Befuddlement Spell keeps the Crimson from waking up. However, it may weaken over time, and you will have to strengthen it.",
             "Do 10 Jumping Jacks/Buddha Claps.", "125px", "122px",
             (playerState) => playerState.knowsCrimson),
-        [Actions.specificActions.STATUE.POWER_CONTAINMENT]: new PlayerAction("The Containment Arrays attempt to isolate the Crimson so that it doesn't sense the artefacts and awaken. You will need to power it to keep the isolation secure.",
+        [Actions.specificActions.STATUE.POWER_CONTAINMENT]: new PlayerAction("Contain Power", "The Containment Arrays attempt to isolate the Crimson so that it doesn't sense the artefacts and awaken. You will need to power it to keep the isolation secure.",
             "Everyone to present a different battery brand/type (including portable batteries).", "376px", "135px",
             (playerState) => playerState.knowsCrimson),
-        [Actions.specificActions.STATUE.PURIFY_CORRUPTION]: new PlayerAction("As the Crimson begins to awaken, it will start to corrupt the surroundings. It draws even more power from this corruption. You will need to purify the corruption to keep the Crimson weak.",
+        [Actions.specificActions.STATUE.PURIFY_CORRUPTION]: new PlayerAction("Purify Corruption", "As the Crimson begins to awaken, it will start to corrupt the surroundings. It draws even more power from this corruption. You will need to purify the corruption to keep the Crimson weak.",
             "Everyone to present a hand sanitiser of different brands.", "100px", "304px",
             (playerState) => playerState.knowsCrimson),
-        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
             "No task required.", "870px", "488px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
             "No task required.", "870px", "543px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
             "No task required.", "689px", "100px"),
-        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("The Statue of Triton has a publicly-accessible storage of Oxygen, which slowly builds up 4 minutes of Oxygen every minute. You can get all the Oxygen inside this store. Note that this storage is shared between everyone." + coolDownMessage, 
-            "Conduct a Water Parade (skip if fasting) to receive all Oxygen stored at the statue.",
+        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("Get Oxygen", "The Statue of Triton has a publicly-accessible storage of Oxygen, which slowly builds up 4 minutes of Oxygen every minute. You can get all the Oxygen inside this store. Note that this storage is shared between everyone." + coolDownMessage, 
+            "Conduct a Water Parade (skip if fasting) to receive all Oxygen stored at the statue." + lastUsedMessage,
             "826px", "238px",
             (playerState) => playerState.streamCooldownExpiry[playerState.locationId] ? new Date(playerState.streamCooldownExpiry[playerState.locationId]) : new Date(0),
             0,
@@ -54,6 +57,7 @@ const Statue = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -76,6 +80,7 @@ const Statue = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -100,7 +105,7 @@ const Statue = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('statue.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Statue.tsx
+++ b/wlclient/src/components/Location/Statue.tsx
@@ -12,7 +12,7 @@ const Statue = (props: SpecificLocationProps): React.ReactElement => {
         ? " You may reuse this service again at " + new Date(playerState.streamCooldownExpiry[playerState.locationId]).toLocaleTimeString()
         : "";
 
-    const lastUsedMessage = globalState // && globalState?.tritonOxygen.lastExtract
+    const lastUsedMessage = globalState?.tritonOxygen.lastExtract
         ? " This Oxygen stream was last used on " + new Date(globalState?.tritonOxygen.lastExtract).toLocaleTimeString()
         : " No group has used this Oxygen stream yet! Be the first!";
     const actions: Record<string, PlayerAction> = {
@@ -25,7 +25,7 @@ const Statue = (props: SpecificLocationProps): React.ReactElement => {
         [Actions.specificActions.STATUE.DECODE_ENGRAVING]: new PlayerAction("Decode Engraving", "You have found an engraving written in the ancient language. Decode it to learn what it says.", 
             "Decode 'Vwwh Ujaekgf'", "250px", "553px",
             (playerState) => playerState.knowsLanguage),
-        [Actions.specificActions.STATUE.CAST_COOLING_AURA]: new PlayerAction("Cast Aura", "The Crimson's body temperature is kept low as part of its slumber. Prevent it from getting too high!",
+        [Actions.specificActions.STATUE.CAST_COOLING_AURA]: new PlayerAction("Cast Cool Aura", "The Crimson's body temperature is kept low as part of its slumber. Prevent it from getting too high!",
             "Water Parade.", "414px", "324px",
             (playerState) => playerState.knowsCrimson),
         [Actions.specificActions.STATUE.STRENGTHEN_BEFUDDLEMENT]: new PlayerAction("Befuddle Harder", "A Befuddlement Spell keeps the Crimson from waking up. However, it may weaken over time, and you will have to strengthen it.",
@@ -71,7 +71,7 @@ const Statue = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -94,7 +94,7 @@ const Statue = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Store.tsx
+++ b/wlclient/src/components/Location/Store.tsx
@@ -1,64 +1,63 @@
 import React from 'react';
-import DynamicAction from './DynamicAction';
-import { DynamicActionProps } from './DynamicAction';
 import { Action, ActionProps } from './Action';
 import { SpecificLocationProps, imgDirectoryGenerator } from './LocationComponent';
 import { Actions } from 'wlcommon';
 import { PlayerAction, DynamicPlayerAction } from '../../PlayerAction';
+import DynamicAction, { DynamicActionProps } from './DynamicAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.STORE.BUY_MAP]: new DynamicPlayerAction("This map will let you find your way to more locations in the Undersea.", 
+    [Actions.specificActions.STORE.BUY_MAP]: new DynamicPlayerAction("Buy Map", "This map will let you find your way to more locations in the Undersea.", 
         "Pay 5 minutes of Oxygen to receive 1 x Map.", "577px", "549px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         300000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },
         (playerState) => !playerState.inventory['Map']),
-    [Actions.specificActions.STORE.BUY_GUIDE]: new DynamicPlayerAction("It's an introduction of all the Oxygen Streams in the Undersea.",
+    [Actions.specificActions.STORE.BUY_GUIDE]: new DynamicPlayerAction("Buy Guide", "It's an introduction of all the Oxygen Streams in the Undersea.",
         "Pay 5 minutes of Oxygen to receive 1 x Guide to the Oxygen Streams of the Undersea.", "717px", "308px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         300000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },
         (playerState) => !playerState.inventory['OxygenGuide']),
-    [Actions.specificActions.STORE.BUY_DOLL]: new DynamicPlayerAction("It's a doll of The Little Mermaid! How cute UWU.",
+    [Actions.specificActions.STORE.BUY_DOLL]: new DynamicPlayerAction("Buy Doll", "It's a doll of The Little Mermaid! How cute UWU.",
         "Pay 10 minutes of Oxygen to receive 1 x Mermaid Doll.", "451px", "221px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         600000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; }),
-    [Actions.specificActions.STORE.BUY_DISCOVERS]: new DynamicPlayerAction("This ticket lets you go on the full tour of the Statue of Triton.", 
+    [Actions.specificActions.STORE.BUY_DISCOVERS]: new DynamicPlayerAction("Buy Ticket", "This ticket lets you go on the full tour of the Statue of Triton.", 
         "Pay 20 minutes of Oxygen to receive 1 x UnderseaDiscovers Ticket.", "278px", "140px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         1200000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; }),
-    [Actions.specificActions.STORE.BUY_PUMP]: new DynamicPlayerAction("This pump allows you to store all your Oxygen before you resurface, so it doesn't go to waste.", 
+    [Actions.specificActions.STORE.BUY_PUMP]: new DynamicPlayerAction("Buy Pump", "This pump allows you to store all your Oxygen before you resurface, so it doesn't go to waste.", 
         "Pay 30 minutes of Oxygen to receive 1 x Oxygen Pump.", "810px", "209px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         1800000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },
         (playerState) => !playerState.inventory['Pump']),
-    [Actions.specificActions.STORE.BUY_BLACK_ROCK]: new DynamicPlayerAction("It's a strange looking black rock. There are odd markings on it. Nobody knows what its uses, or properties are...", 
+    [Actions.specificActions.STORE.BUY_BLACK_ROCK]: new DynamicPlayerAction("Buy Rock", "It's a strange looking black rock. There are odd markings on it. Nobody knows what its uses, or properties are...", 
         "Pay 30 minutes of Oxygen to receive 1 x Mysterious Black Rock.", "252px", "495px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         1800000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },),
-    [Actions.specificActions.STORE.BUY_BUBBLE_PASS]: new DynamicPlayerAction("This golden pass lets you access the Bubble Factory. It has no expiry date and can be used multiple times.", 
+    [Actions.specificActions.STORE.BUY_BUBBLE_PASS]: new DynamicPlayerAction("Buy Bubble Pass", "This golden pass lets you access the Bubble Factory. It has no expiry date and can be used multiple times.", 
         "Pay 40 minutes of Oxygen to receive 1 x Bubble Pass.", "433px", "344px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         2400000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },),
-    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
         "No task required.", "870px", "488px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
         "No task required.", "870px", "543px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
         "No task required.", "99px", "251px")
 }
 
@@ -68,6 +67,7 @@ const Store = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -90,6 +90,7 @@ const Store = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,

--- a/wlclient/src/components/Location/Store.tsx
+++ b/wlclient/src/components/Location/Store.tsx
@@ -81,7 +81,7 @@ const Store = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
         }));
         
     const dynamicActionProps = Object.entries(actions)
@@ -104,7 +104,7 @@ const Store = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/TravelPopup.tsx
+++ b/wlclient/src/components/Location/TravelPopup.tsx
@@ -68,7 +68,7 @@ const TravelPopup = (props: TravelPopupProps): React.ReactElement => {
                             const display = { display: travellable ? "" : "none"}
                             return (
                                 <button className="travelButton" style={display}
-                                    key=""
+                                    key={locationId}
                                     onClick={handleTravelClosePopup(
                                         location.id
                                     )}

--- a/wlclient/src/components/Location/Tuna.tsx
+++ b/wlclient/src/components/Location/Tuna.tsx
@@ -45,7 +45,7 @@ const Tuna = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -68,7 +68,7 @@ const Tuna = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Tuna.tsx
+++ b/wlclient/src/components/Location/Tuna.tsx
@@ -4,7 +4,6 @@ import { SpecificLocationProps, imgDirectoryGenerator } from './LocationComponen
 import { Actions } from 'wlcommon';
 import { DynamicPlayerAction, PlayerAction } from '../../PlayerAction';
 import DynamicAction, { DynamicActionProps } from './DynamicAction';
-
 const Tuna = (props: SpecificLocationProps): React.ReactElement => {
     const { playerState, handleAction, triggerTooltip, isMentor } = props;
 
@@ -13,15 +12,15 @@ const Tuna = (props: SpecificLocationProps): React.ReactElement => {
         : "";
 
     const actions: Record<string, PlayerAction> = {
-        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
             "No task required.", "870px", "488px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+        [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
             "No task required.", "870px", "543px",
             (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+        [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
             "No task required.", "615px", "141px"),
-        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("There is a large Oxygen Stream here, however, it has fallen into disrepair. Getting Oxygen from here will be slightly more challenging, but you can still expect to get 40 minutes of Oxygen here." + coolDownMessage,
+        [Actions.ALL_OXYGEN.GET_OXYGEN]: new DynamicPlayerAction("Get Oxygen", "There is a large Oxygen Stream here, however, it has fallen into disrepair. Getting Oxygen from here will be slightly more challenging, but you can still expect to get 40 minutes of Oxygen here." + coolDownMessage,
             "2 Cadets to be blindfolded, while the rest of the group are to instruct them to draw a wrench and toolbox respectively.", "198px", "491px",
             (playerState) => playerState.streamCooldownExpiry[playerState.locationId] ? new Date(playerState.streamCooldownExpiry[playerState.locationId]) : new Date(0),
             0,
@@ -32,6 +31,7 @@ const Tuna = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -54,6 +54,7 @@ const Tuna = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -78,7 +79,7 @@ const Tuna = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('tuna.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Umbral.tsx
+++ b/wlclient/src/components/Location/Umbral.tsx
@@ -50,7 +50,7 @@ const Umbral = (props: SpecificLocationProps): React.ReactElement => {
                 playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
             handleAction: handleAction(actionId),
             triggerTooltip: triggerTooltip,
-            tooltipInfo: [actionId, playerAction.description, playerAction.task]
+            tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
     
     const dynamicActionProps = Object.entries(actions)
@@ -73,7 +73,7 @@ const Umbral = (props: SpecificLocationProps): React.ReactElement => {
                         dynamicPlayerAction.getEnabled ? dynamicPlayerAction.getEnabled(playerState) : true,
                     handleAction: handleAction(actionId),
                     triggerTooltip: triggerTooltip,
-                    tooltipInfo: [actionId, dynamicPlayerAction.description, dynamicPlayerAction.task]
+                    tooltipInfo: [playerAction.display, dynamicPlayerAction.description, dynamicPlayerAction.task]
                 },
                 timeToCompare: dynamicPlayerAction.timeToCompare(playerState),
                 howRecentToTrigger: dynamicPlayerAction.howRecentToTrigger,

--- a/wlclient/src/components/Location/Umbral.tsx
+++ b/wlclient/src/components/Location/Umbral.tsx
@@ -6,27 +6,27 @@ import { DynamicPlayerAction, PlayerAction } from '../../PlayerAction';
 import DynamicAction, { DynamicActionProps } from './DynamicAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.UMBRAL.EXPLORE]: new DynamicPlayerAction("This is a shady, run-down area. Apparently it used to be a residential district, but the Oxygen Stream here vanished one day, suddenly. You shudder as you walk around the area.", 
+    [Actions.specificActions.UMBRAL.EXPLORE]: new DynamicPlayerAction("Explore", "This is a shady, run-down area. Apparently it used to be a residential district, but the Oxygen Stream here vanished one day, suddenly. You shudder as you walk around the area.", 
         "Use 5 minutes of Oxygen.", "656px", "402px",
         (playerState) => playerState.oxygenUntil ? new Date(playerState.oxygenUntil) : new Date(0),
         300000,
         (setIsVisible, setIsEnabled): void => { setIsEnabled(false); },
         (): void => { return; },),
-    [Actions.specificActions.UMBRAL.GIVE_PAN]: new PlayerAction("Give Alyusi the Pyrite Pan.", 
+    [Actions.specificActions.UMBRAL.GIVE_PAN]: new PlayerAction("Give Pyrite Pan", "Give Alyusi the Pyrite Pan.", 
         "Give 1 x Pyrite Pan.", "579px", "197px",
         (playerState) => playerState.quests[questIds.CLOAK_2]?.status === 'incomplete',
         (playerState) => playerState.inventory[itemDetails.PYRITE_PAN.id] !== undefined),
-    [Actions.specificActions.UMBRAL.GIVE_ROCK]: new PlayerAction("Give Alyusi the Chmyrrkyth.", 
+    [Actions.specificActions.UMBRAL.GIVE_ROCK]: new PlayerAction("Give Rock", "Give Alyusi the Chmyrrkyth.", 
         "Give 1 x Mysterious Black Rock.", "749px", "177px",
         (playerState) => playerState.quests[questIds.CLOAK_1]?.status === 'incomplete',
         (playerState) => playerState.inventory[itemDetails.BLACK_ROCK.id] !== undefined),
-    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.STORE_OXYGEN]: new PlayerAction("Store Oxygen", "Store all your Oxygen (except 2 mins, enough for you to resurface) into your Oxygen Pump.", 
         "No task required.", "870px", "488px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw all Oxygen from your Oxygen Pump.", 
+    [Actions.ALL_UNDERWATER.WITHDRAW_OXYGEN]: new PlayerAction("Withdraw Oxygen", "Withdraw all Oxygen from your Oxygen Pump.", 
         "No task required.", "870px", "543px",
         (playerState) => playerState.storedOxygen !== null && playerState.challengeMode !== null),
-    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
+    [Actions.ALL_UNDERWATER.RESURFACE]: new PlayerAction("Resurface", "Return to Sleepy Shore. Note that when you return to the surface, all your oxygen will be lost as it escapes into the air!",
         "No task required.", "60px", "304px")
 }
 
@@ -36,6 +36,7 @@ const Umbral = (props: SpecificLocationProps): React.ReactElement => {
     const actionProps = Object.entries(actions)
         .filter(([, playerAction]) => !(playerAction instanceof DynamicPlayerAction))
         .map(([actionId, playerAction]) => ({
+            display: playerAction.display,
             action: actionId,
             x: playerAction.x,
             y: playerAction.y,
@@ -58,6 +59,7 @@ const Umbral = (props: SpecificLocationProps): React.ReactElement => {
             const dynamicPlayerAction = playerAction as DynamicPlayerAction;
             return {
                 actionProps: {
+                    display: playerAction.display,
                     action: actionId,
                     x: dynamicPlayerAction.x,
                     y: dynamicPlayerAction.y,
@@ -82,7 +84,7 @@ const Umbral = (props: SpecificLocationProps): React.ReactElement => {
     
     return (
         <React.Fragment>
-            <img src={imgDirectoryGenerator('corals.png')} />
+            <img src={imgDirectoryGenerator('umbral.png')} />
             {actionProps.map((info: ActionProps, index) => {
                 return <Action key={index} {...info} />;
             })}

--- a/wlclient/src/components/Location/Woods.tsx
+++ b/wlclient/src/components/Location/Woods.tsx
@@ -27,7 +27,7 @@ const Woods = (props: SpecificLocationProps): React.ReactElement => {
             playerAction.getEnabled ? playerAction.getEnabled(playerState) : true,
         handleAction: handleAction(actionId),
         triggerTooltip: triggerTooltip,
-        tooltipInfo: [actionId, playerAction.description, playerAction.task]
+        tooltipInfo: [playerAction.display, playerAction.description, playerAction.task]
     }));
 
     return (

--- a/wlclient/src/components/Location/Woods.tsx
+++ b/wlclient/src/components/Location/Woods.tsx
@@ -5,7 +5,7 @@ import { Actions } from 'wlcommon';
 import { PlayerAction } from '../../PlayerAction';
 
 const actions: Record<string, PlayerAction> = {
-    [Actions.specificActions.WOODS.GET_HAIR]: new PlayerAction("It is said that a herd of unicorns live in the Whispering Woods, and they only appear to the pure of heart. Fortunately, we only need to find the hair that they shed.", 
+    [Actions.specificActions.WOODS.GET_HAIR]: new PlayerAction("Get Hair", "It is said that a herd of unicorns live in the Whispering Woods, and they only appear to the pure of heart. Fortunately, we only need to find the hair that they shed.", 
         "Share a point in time when you received help and support from others to receive 1 X Unicorn Hair.", "703px", "382px")
 }
 
@@ -13,6 +13,7 @@ const Woods = (props: SpecificLocationProps): React.ReactElement => {
     const { playerState, handleAction, triggerTooltip, isMentor } = props;
 
     const actionProps = Object.entries(actions).map(([actionId, playerAction]) => ({
+        display: playerAction.display,
         action: actionId,
         x: playerAction.x,
         y: playerAction.y,

--- a/wlclient/src/components/Login.tsx
+++ b/wlclient/src/components/Login.tsx
@@ -55,7 +55,6 @@ const Login = (props: LoginProps): React.ReactElement => {
             setErrorMessage(payload as string);
         } else {
             updateLoggedIn(true);
-            console.log(mode);
             if (mode !== 'admin') {
                 const {
                     updatePlayerState,


### PR DESCRIPTION
Change display names for actions
Revert backgrounds to the correct images
Showing last used timing for triton oxygen stream
Remove esLint warnings by eliminating key=""
Change tooltip action name to match action name
UI changes:
- Make action box slightly bigger for the words
- align the location title to the centre